### PR TITLE
Adding detailed logs

### DIFF
--- a/raet/road/estating.py
+++ b/raet/road/estating.py
@@ -396,12 +396,15 @@ class RemoteEstate(Estate):
             if rf and not self.validRsid(sid):
                 transaction.nack()
                 self.removeTransaction(index)
-                emsg = ("Stack {0}: Stale correspondent {1} from remote {1} at {2}"
-                            "\n".format(self.stack.name,
+                emsg = ("Stack {0}: Stale correspondent {1} from remote {2} "
+                        "at {3}".format(self.stack.name,
                                         index,
                                         self.name,
                                         self.stack.store.stamp))
                 console.terse(emsg)
+                console.verbose("{0} has last sid {1}".
+                                format(self.name, self.rsid))
+                console.terse("\n")
                 self.stack.incStat('stale_correspondent')
         self.doneTransactions.clear()
 
@@ -432,17 +435,21 @@ class RemoteEstate(Estate):
             rf = index[0]
             sid = index[3]
 
-            if not rf and not self.validSid(sid): # transaction sid newer or equal
+            if not rf and not self.validSid(
+                    sid):  # transaction sid newer or equal
                 if transaction.kind in [TrnsKind.message]:
                     self.saveMessage(transaction)
                 transaction.nack()
                 self.removeTransaction(index)
                 emsg = ("Stack {0}: Stale initiator {1} to remote {2} at {3}"
-                        "\n".format(self.stack.name,
-                                    index,
-                                    self.name,
-                                    self.stack.store.stamp))
+                        .format(self.stack.name,
+                                index,
+                                self.name,
+                                self.stack.store.stamp))
                 console.terse(emsg)
+                console.verbose("{0} has last sid {1}".
+                                format(self.name, self.rsid))
+                console.terse("\n")
                 self.stack.incStat('stale_initiator')
 
     def saveMessage(self, messenger):

--- a/raet/road/packeting.py
+++ b/raet/road/packeting.py
@@ -476,6 +476,18 @@ class RxFoot(Foot):
             msg = front + blank
             if not self.packet.verify(signature, msg):
                 emsg = "Failed verification"
+                nuid = self.packet.data['de']
+                stack = self.packet.stack
+                if nuid not in stack.remotes:
+                    console.verbose('nuid {} not in remotes {} of {}'.
+                                    format(nuid,
+                                           tuple(stack.remotes.keys()), stack))
+                else:
+                    remote = self.packet.stack.remotes[nuid]
+                    verkey = remote.verfer.keyhex
+                    console.verbose("Verification failed for remote {} with "
+                                    "nuid {} using key {}".
+                                    format(remote.name, nuid, verkey))
                 raise raeting.PacketError(emsg)
 
         if fk == FootKind.nada:

--- a/raet/road/stacking.py
+++ b/raet/road/stacking.py
@@ -548,9 +548,10 @@ class RoadStack(stacking.KeepStack):
                         return
 
         else: # not join transaction
+            sha = (packet.data.get('sh', ''), packet.data.get('sp', ''))
             if rsid == 0: # cannot use sid == 0 on nonjoin transaction
                 emsg = ("Stack '{0}'. Invalid Zero sid '{1}' for transaction {2} packet"
-                       " {3}. Dropping...\n".format(self.name, rsid, tk, pk ))
+                       " {3}. Dropping...\n".format(self.name, rsid, tk, pk))
                 console.terse(emsg)
                 self.incStat('invalid_sid')
                 return
@@ -568,9 +569,10 @@ class RoadStack(stacking.KeepStack):
             if remote:
                 if not cf: # packet from remotely initiated transaction
                     if not remote.validRsid(rsid): # invalid rsid
-                        emsg = ("Stack '{0}'. Invalid nonjoin from '{1}'. Invalid sid "
-                                " {2} in packet. Dropping...\n".format(self.name,
-                                                            remote.name, rsid,))
+                        emsg = ("Stack '{0}'. Invalid nonjoin from '{1}'. "
+                                "Invalid sid {2} in packet, old sid is {3}. "
+                                "Dropping...\n".format(self.name, remote.name,
+                                                       rsid, remote.rsid))
                         console.terse(emsg)
                         self.incStat('stale_sid')
                         self.replyStale(packet, remote) # nack stale transaction

--- a/raet/road/transacting.py
+++ b/raet/road/transacting.py
@@ -2177,8 +2177,11 @@ class Allowent(Correspondent):
             lfqdn = lfqdn.encode('ascii', 'ignore')
         lfqdn = lfqdn.ljust(128, b' ')[:128].rstrip(b' ')
         if fqdn != lfqdn:
-            emsg = "Mismatch of fqdn in initiate stuff\n"
+            emsg = "Mismatch of fqdn in initiate stuff."
             console.terse(emsg)
+            console.verbose(" Local fqdn is {0} and received fqdn is {1}.".
+                            format(lfqdn, fqdn))
+            console.terse("\n")
             #self.stack.incStat('invalid_initiate')
             #self.remove()
             #self.nack(kind=raeting.pcktKinds.reject)


### PR DESCRIPTION
Encountered following logs for a long running stack in auto mode `always` and accepting connections from a variety of clients.

`Stack 'Alpha'. Invalid nonjoin from 'zJ8Y9L'. Invalid sid  1 in packet. Dropping...`

`Stack Alpha: Stale correspondent (True, .., ...) from remote Mq14ZZ`

`Mismatch of fqdn in initiate stuff`

`Stack 'Alpha'. Stale join initiatance from '('x.y.z.z', b)', Not a request and no remote. Dropping...`
